### PR TITLE
Update login hostname

### DIFF
--- a/user-guide/connecting.rst
+++ b/user-guide/connecting.rst
@@ -252,18 +252,18 @@ an entry in this file which may look something like:
 ::
 
     Host tesseract
-      HostName tesseract-login1.dirac.ed.ac.uk
+      HostName tesseract.dirac.ed.ac.uk
       User user
       ForwardAgent yes
 
 (remember to replace "user" with your username).
 
-The "Host cirrus" line defines a short name for the entry. In this case,
-instead of typing "ssh tesseract-login1.dirac.ed.ac.uk" to access the Tesseract login
-nodes, you could use "ssh tesseract-login1" instead. The remaining lines define
-the options for the "tesseract-login1" host.
+The "Host tesseract" line defines a short name for the entry. In this case,
+instead of typing "ssh tesseract.dirac.ed.ac.uk" to access the Tesseract login
+nodes, you could use "ssh tesseract" instead. The remaining lines define
+the options for the "tesseract" host.
 
--  ``Hostname tesseract-login1.dirac.ed.ac.uk`` - defines the full address of the
+-  ``Hostname tesseract.dirac.ed.ac.uk`` - defines the full address of the
    host
 -  ``User username`` - defines the username to use by default for this
    host (replace "username" with your own username on the remote host)

--- a/user-guide/connecting.rst
+++ b/user-guide/connecting.rst
@@ -51,7 +51,7 @@ Tesseract:
 
 ::
 
-    ssh username@tesseract-login1.dirac.ed.ac.uk
+    ssh username@tesseract-login.dirac.ed.ac.uk
 
 To allow remote programs, especially graphical applications to control
 your local display, such as being able to open up a new GUI window (such
@@ -59,7 +59,7 @@ as for a debugger), use:
 
 ::
 
-    ssh -X username@tesseract-login1.dirac.ed.ac.uk
+    ssh -X username@tesseract-login.dirac.ed.ac.uk
 
 Some sites recommend using the ``-Y`` flag. While this can fix some
 compatibility issues, the ``-X`` flag is more secure.

--- a/user-guide/transfer.rst
+++ b/user-guide/transfer.rst
@@ -13,7 +13,7 @@ command to transfer a single file to Tesseract:
 
 ::
 
-    scp [options] source_file user@tesseract-login1.dirac.ed.ac.uk:[destination]
+    scp [options] source_file user@tesseract-login.dirac.ed.ac.uk:[destination]
 
 In the above example, the ``[destination]`` is optional, as when left
 out scp will simply copy the source into the users home directory.
@@ -30,7 +30,7 @@ machine. To transfer files to Tesseract the command should have the form:
 
 ::
 
-    rsync [options] -e ssh source user@tesseract-login1.dirac.ed.ac.uk:[destination]
+    rsync [options] -e ssh source user@tesseract-login.dirac.ed.ac.uk:[destination]
 
 In the above example, the ``[destination]`` is optional, as when left
 out rsync will simply copy the source into the users home directory.


### PR DESCRIPTION
"tesseract.dirac.ed.ac.uk" points to both login servers, allowing us to take a node out of service, and also providing simple load balancing.  In addition, the login IPs each server hosts are cluster-managed - if one server goes down, the other server will handle requests bound for either.  As such, users should never need to specify "login1" or "login2"